### PR TITLE
bundling manage-module permissions

### DIFF
--- a/components/security/user-profile/src/main/resources/META-INF/component.xml
+++ b/components/security/user-profile/src/main/resources/META-INF/component.xml
@@ -1,0 +1,96 @@
+<component xmlns="http://products.wso2.org/carbon">
+    <ManagementPermissions>
+        <ManagementPermission>
+            <DisplayName>UI Module Permission</DisplayName>
+            <ResourceId>/permission/UIModulePermission</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>API Blacklist</DisplayName>
+            <ResourceId>/permission/UIModulePermission/apiBlacklist</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Workflow History</DisplayName>
+            <ResourceId>/permission/UIModulePermission/workFlowHistory</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Approved On</DisplayName>
+            <ResourceId>/permission/UIModulePermission/workFlowHistory/showApprovedOn</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Visible</DisplayName>
+            <ResourceId>/permission/UIModulePermission/workFlowHistory/visible</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Application</DisplayName>
+            <ResourceId>/permission/UIModulePermission/application</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Credit Plan</DisplayName>
+            <ResourceId>/permission/UIModulePermission/application/CreditPlan</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Tiers</DisplayName>
+            <ResourceId>/permission/UIModulePermission/application/changeTiers</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Visible</DisplayName>
+            <ResourceId>/permission/UIModulePermission/application/visible</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Edit Subscription</DisplayName>
+            <ResourceId>/permission/UIModulePermission/edit-subscription</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Quota</DisplayName>
+            <ResourceId>/permission/UIModulePermission/quota</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Operator List</DisplayName>
+            <ResourceId>/permission/UIModulePermission/quota/operatorList</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Visible</DisplayName>
+            <ResourceId>/permission/UIModulePermission/quota/visible</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Rate</DisplayName>
+            <ResourceId>/permission/UIModulePermission/rate</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Add</DisplayName>
+            <ResourceId>/permission/UIModulePermission/rate/add</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Assign</DisplayName>
+            <ResourceId>/permission/UIModulePermission/rate/assign</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>View</DisplayName>
+            <ResourceId>/permission/UIModulePermission/rate/view</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>SP Blacklist</DisplayName>
+            <ResourceId>/permission/UIModulePermission/spBlackList</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Subscription</DisplayName>
+            <ResourceId>/permission/UIModulePermission/subscription</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Rates</DisplayName>
+            <ResourceId>/permission/UIModulePermission/subscription/changeRates</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Tiers</DisplayName>
+            <ResourceId>/permission/UIModulePermission/subscription/changeTiers</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Visible</DisplayName>
+            <ResourceId>/permission/UIModulePermission/subscription/visible</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Whitelist</DisplayName>
+            <ResourceId>/permission/UIModulePermission/whiteList</ResourceId>
+        </ManagementPermission>
+    </ManagementPermissions>
+</component>


### PR DESCRIPTION
This change adds the user permissions required for manage-module automatically when the user-profile jar is deployed. This means that we do not have to run the DB script manually to deploy permissions.