### PR TITLE
[INTGW-793] [INTGW-794] Issues fixed in DbUtils classes

### DIFF
--- a/components/dbutil/src/main/java/com/wso2telco/core/dbutils/DbUtils.java
+++ b/components/dbutil/src/main/java/com/wso2telco/core/dbutils/DbUtils.java
@@ -319,7 +319,7 @@ public class DbUtils {
      * @throws Exception the exception
      */
     public static String format(double doubData, int precision, int scale) throws Exception {
-        BigDecimal decData = new BigDecimal(doubData);
+        BigDecimal decData = BigDecimal.valueOf(doubData);
         decData = decData.setScale(scale, BigDecimal.ROUND_HALF_EVEN);
         String strData = decData.toString();
 

--- a/components/dbutil/src/main/java/com/wso2telco/core/dbutils/DbUtils.java
+++ b/components/dbutil/src/main/java/com/wso2telco/core/dbutils/DbUtils.java
@@ -68,9 +68,9 @@ public class DbUtils {
     /**
      * The datasource.
      */
-    private static volatile DataSource Datasource = null;
+    private static DataSource Datasource = null;
 
-    private static volatile DataSource connectDatasource = null;
+    private static DataSource connectDatasource = null;
 
     /**
      * The Constant DEP_DATA_SOURCE.

--- a/components/dbutil/src/main/java/com/wso2telco/dbutils/DbUtils.java
+++ b/components/dbutil/src/main/java/com/wso2telco/dbutils/DbUtils.java
@@ -64,7 +64,7 @@ public class DbUtils {
     /**
      * The axiata datasource.
      */
-    private static volatile DataSource axiataDatasource = null;
+    private static DataSource axiataDatasource = null;
 
     /**
      * The Constant AXIATA_DATA_SOURCE.

--- a/components/dbutil/src/main/java/com/wso2telco/dbutils/DbUtils.java
+++ b/components/dbutil/src/main/java/com/wso2telco/dbutils/DbUtils.java
@@ -226,7 +226,7 @@ public class DbUtils {
      * @throws Exception the exception
      */
     public static String format(double doubData, int precision, int scale) throws Exception {
-        BigDecimal decData = new BigDecimal(doubData);
+        BigDecimal decData = BigDecimal.valueOf(doubData);
         decData = decData.setScale(scale, BigDecimal.ROUND_HALF_EVEN);
         String strData = decData.toString();
 


### PR DESCRIPTION
- "BigDecimal.valueOf" used instead of "new BigDecimal"
- Remove the "volatile" keyword from Non-primitive fields