### PR TITLE
[INTGW-784] double checked locking removed

### DIFF
--- a/components/mnc-resolver/src/main/java/com/wso2telco/core/mnc/resolver/dnsssl/SSLClient.java
+++ b/components/mnc-resolver/src/main/java/com/wso2telco/core/mnc/resolver/dnsssl/SSLClient.java
@@ -18,12 +18,8 @@ package com.wso2telco.core.mnc.resolver.dnsssl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
-
-// TODO: Auto-generated Javadoc
 
 /**
  * The Class SSLClient.
@@ -57,59 +53,17 @@ public class SSLClient {
      * @param host the host
      * @param port the port
      * @throws IOException              Signals that an I/O exception has occurred.
-     * @throws NoSuchAlgorithmException the no such algorithm exception
-     * @throws KeyManagementException   the key management exception
      */
-    public void initialize(final String host, final int port)
-            throws IOException, NoSuchAlgorithmException, KeyManagementException {
+    public synchronized void initialize(final String host, final int port) throws IOException {
         SSLSocketFactory socketFactory = (SSLSocketFactory) SSLSocketFactory.getDefault();
 
         if (sslsocket == null) {
-        /*            
-                    //temp to bypass proxy
-                                    TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager() {
-                public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-                    return null;
-                }
+            sslsocket = (SSLSocket) socketFactory.createSocket(host, port);
 
-                public void checkClientTrusted(X509Certificate[] certs, String authType) {
-                }
-
-                public void checkServerTrusted(X509Certificate[] certs, String authType) {
-                }
-            }
-                };
-
-                // Install the all-trusting trust manager
-                SSLContext sc = SSLContext.getInstance("SSL");
-                sc.init(null, trustAllCerts, new java.security.SecureRandom());
-                HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
-
-                // Create all-trusting host name verifier
-                HostnameVerifier allHostsValid = new HostnameVerifier() {
-                    public boolean verify(String hostname, SSLSession session) {
-                        return true;
-                    }
-                };
-
-                // Install the all-trusting host verifier
-                //HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
-                    
-                   SSLSocketFactory socketFactory = sc.getSocketFactory(); 
-  */
-            synchronized (SSLClient.class) {
-
-                if (sslsocket == null) {
-                    sslsocket = (SSLSocket) socketFactory.createSocket(host, port);
-                }
-
-                // Set the keep alive setting to true
-                sslsocket.setKeepAlive(true);
-
-                sslis = sslsocket.getInputStream();
-
-                sslos = sslsocket.getOutputStream();
-            }
+            // Set the keep alive setting to true
+            sslsocket.setKeepAlive(true);
+            sslis = sslsocket.getInputStream();
+            sslos = sslsocket.getOutputStream();
         }
     }
 

--- a/components/pcr-service/src/main/java/com/wso2telco/core/pcrservice/util/RedisUtil.java
+++ b/components/pcr-service/src/main/java/com/wso2telco/core/pcrservice/util/RedisUtil.java
@@ -3,7 +3,6 @@ package com.wso2telco.core.pcrservice.util;
 import java.util.Map;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 
@@ -11,21 +10,17 @@ public class RedisUtil {
 
     private static JedisPool pool = null;
 
-    public static JedisPool getInstance() {
+    public static synchronized JedisPool getInstance() {
         if (pool == null) {
-            synchronized (RedisUtil.class) {
-                if (pool == null) {
-                    Map<Object, Object> redis = (Map<Object, Object>) YamlReader.getConfiguration().getRedis();
-                    String redisHost = (String) redis.get("host");
-                    int redisPort = (int) redis.get("port");
-                    String password = (String) redis.get("password");
-                    int timeout = (int) redis.get("timeout");
-                    int jedisPoolSize = (int) redis.get("poolsize");
-                    JedisPoolConfig poolConfig = new JedisPoolConfig();
-                    poolConfig.setMaxTotal(jedisPoolSize);
-                    pool = new JedisPool(new GenericObjectPoolConfig(), redisHost, redisPort, timeout, password);
-                }
-            }
+            Map<Object, Object> redis = (Map<Object, Object>) YamlReader.getConfiguration().getRedis();
+            String redisHost = (String) redis.get("host");
+            int redisPort = (int) redis.get("port");
+            String password = (String) redis.get("password");
+            int timeout = (int) redis.get("timeout");
+            int jedisPoolSize = (int) redis.get("poolsize");
+            JedisPoolConfig poolConfig = new JedisPoolConfig();
+            poolConfig.setMaxTotal(jedisPoolSize);
+            pool = new JedisPool(new GenericObjectPoolConfig(), redisHost, redisPort, timeout, password);
         }
         return pool;
     }


### PR DESCRIPTION
DCL removed according to the following mail thread;
**SonarQube Error - Double-checked locking should not be used (squid:S2168)**

> From: Salinda Karunarathna <salinda.karunarathna@apigate.com>
> Sent: Monday, October 14, 2019 10:23 AM
> To: Charith De Silva <charith@apigate.com>; Chathura Gunapala <chathura.gunapala@apigate.com>; Apigate Engineering Implementation <implementation@apigate.com>; Amila De Silva <amila@apigate.com>
> Cc: Priyanka Kulathilaka <priyanka@apigate.com>; Chinthana Pannila <chinthana@apigate.com>
> Subject: RE: SonarQube Error - Double-checked locking should not be used (squid:S2168)
> 
> Hi Chathura,
> 
> Here are few solutions.
> 1. Remove the double checked lock and synchronize the whole method instead.
> 2. Use static inner class to hold reference and create instance.
> 
> Here is the explanation,
> In the aforementioned 1st solution has some performance impact in the earlier java version. This has improved in new versions.
> Refer https://www.oracle.com/technetwork/java/6-performance-137236.html#2.1.1.
> With the second solution, we are trying to increase coupling. This will be a headache in unit testing.
> So the better approach is the first one. This will not affect to the performance since we are using java 8+.
> 
> Salinda
> 
> From: Charith De Silva
> Sent: Friday, October 11, 2019 11:37 AM
> To: Chathura Gunapala <chathura.gunapala@apigate.com>; Apigate Engineering Implementation <implementation@apigate.com>; Amila De Silva <amila@apigate.com>
> Cc: Priyanka Kulathilaka <priyanka@apigate.com>; Chinthana Pannila <chinthana@apigate.com>
> Subject: Re: SonarQube Error - Double-checked locking should not be used (squid:S2168)
> 
> Can you not make the initialize method synchronized and get rid of the double check?
> 
> From: Chathura Gunapala <chathura.gunapala@apigate.com>
> Date: Thursday, October 10, 2019 at 6:15 PM
> To: Apigate Engineering Implementation <implementation@apigate.com>
> Cc: Priyanka Kulathilaka <priyanka@apigate.com>, Chinthana Pannila <chinthana@apigate.com>
> Subject: SonarQube Error - Double-checked locking should not be used (squid:S2168)
> 
> Hi All,
> 
> While trying to fix the issues reported by SonarQube, just noticed the following issue,
> 
> Remove this dangerous instance of double-checked locking
> Sonar Rule: squid:S2168
> 
> As a fix for this issue, If I put volatile keyword before sslsocket object reference, SonarQube is giving following error
> Non-primitive fields should not be "volatile" (squid:S3077)
> So what is the correct way to fix this issue?
> 
> Chathura Gunapala